### PR TITLE
chore: update faker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/sainak/go-module-assignment
 
 go 1.19
 
-require github.com/bxcodec/faker/v3 v3.8.1 // indirect
+require github.com/go-faker/faker/v4 v4.0.0
+
+require golang.org/x/text v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-github.com/bxcodec/faker/v3 v3.8.1 h1:qO/Xq19V6uHt2xujwpaetgKhraGCapqY2CRWGD/SqcM=
-github.com/bxcodec/faker/v3 v3.8.1/go.mod h1:DdSDccxF5msjFo5aO4vrobRQ8nIApg8kq3QWPEQD6+o=
+github.com/go-faker/faker/v4 v4.0.0 h1:tfgFaeizVlYGOS1tVo/vcWcKhkNgG1NWm8ibRG0f+aQ=
+github.com/go-faker/faker/v4 v4.0.0/go.mod h1:uuNc0PSRxF8nMgjGrrrU4Nw5cF30Jc6Kd0/FUTTYbhg=
+golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/bxcodec/faker/v3"
+	"github.com/go-faker/faker/v4"
 )
 
 type User struct {


### PR DESCRIPTION
Replace github.com/bxcodec/faker/v3 with github.com/go-faker/faker/v4
The api changes are backward compatible for our use case,
hence no code changes are required.